### PR TITLE
Fix usage commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,19 @@ LLM-powered ghostwriter for [Hypothesis](https://hypothesis.readthedocs.io/). _g
 
 3. You will also have to [set up OAuth](https://ai.google.dev/gemini-api/docs/oauth) on your Google Cloud project to obtain a `client_secret.json` file to be placed in the root directory of this repository. Once you have installed the [gCloud CLI](https://cloud.google.com/sdk/docs/install), run the following command to authenticate yourself.
 
+For authenticating locally, use the following:
+
 ```bash
 gcloud auth application-default login \
-    # --no-browser \
+    --client-id-file=client_secret.json \
+    --scopes='https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/generative-language.retriever'
+```
+
+For collab, use this:
+
+```bash
+gcloud auth application-default login \
+    --no-browser \
     --client-id-file=client_secret.json \
     --scopes='https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/generative-language.retriever'
 ```
@@ -26,7 +36,7 @@ gcloud auth application-default login \
 ## Usage
 
 ```python
-from ghaiswriter import generate_strategy
+from ghaistwriter import generate_strategy
 
 strategy = generate_strategy("function description")
 ```

--- a/README.md
+++ b/README.md
@@ -14,22 +14,13 @@ LLM-powered ghostwriter for [Hypothesis](https://hypothesis.readthedocs.io/). _g
 
 3. You will also have to [set up OAuth](https://ai.google.dev/gemini-api/docs/oauth) on your Google Cloud project to obtain a `client_secret.json` file to be placed in the root directory of this repository. Once you have installed the [gCloud CLI](https://cloud.google.com/sdk/docs/install), run the following command to authenticate yourself.
 
-For authenticating locally, use the following:
-
 ```bash
 gcloud auth application-default login \
     --client-id-file=client_secret.json \
     --scopes='https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/generative-language.retriever'
 ```
 
-For collab, use this:
-
-```bash
-gcloud auth application-default login \
-    --no-browser \
-    --client-id-file=client_secret.json \
-    --scopes='https://www.googleapis.com/auth/cloud-platform,https://www.googleapis.com/auth/generative-language.retriever'
-```
+You can add the `--no-browser` flag to the above command if you are working on a remote environment (for example, Google Colab).
 
 4. Install the required dependencies using `pip install -r requirements.txt`.
 


### PR DESCRIPTION
Fixed usage commands in README regarding:
1. Authentication
2. File name for importing generate_strategy function (`ghaiswriter` to `ghaistwriter`)
 